### PR TITLE
Fix changelog format

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,10 +4,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
-## [2.0] - 2022-01-28
+## [Unreleased]
 
-### New Version
-- Version 2.0 for WordPress 5.9
+### Added
+- Add option to sync WooCommerce customers
+
+### Fixed
+- Plugin is compatible with Wordpress 5.9. 
+
+### Removed
+- Removed support for legacy API
 
 ## [1.8.1] - 2016-10-29
 
@@ -24,7 +30,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Added
 - Add German translation
 
-[2.0]: https://github.com/mailrelay/wordpress/compare/v1.8.0...v2.0
+[Unreleased]: https://github.com/mailrelay/wordpress/compare/v1.8.1...HEAD
 [1.8.1]: https://github.com/mailrelay/wordpress/compare/v1.8.0...v1.8.1
 [1.8.0]: https://github.com/mailrelay/wordpress/compare/v1.7.4...v1.8.0
 [1.7.4]: https://github.com/mailrelay/wordpress/compare/v1.7.3...v1.7.4

--- a/src/readme.txt
+++ b/src/readme.txt
@@ -41,7 +41,9 @@ Once this data is successfully saved you can run the user sync.
 = 2.0 =
 *Release Date - 28 Jan 2022*
 
-* New version for WordPress 5.9
+* Add option to sync WooCommerce customers
+* Plugin is compatible with Wordpress 5.9.
+* Removed support for legacy API
 
 = 1.8.1 =
 *Release Date - 29 Oct 2016*


### PR DESCRIPTION
- Use keepachangelog.com format.
- Keep v2 tags as unreleased at this moment.