### PR TITLE
Update common.php

### DIFF
--- a/src/inc/common.php
+++ b/src/inc/common.php
@@ -77,6 +77,9 @@ if ( ! function_exists( 'mailrelay_sync_user' ) ) {
 		}
 
 		$full_name = $user->first_name . ' ' . $user->last_name;
+		if ( $full_name == ' ') {
+			$full_name = $user->display_name;
+		}
 		$data      = array(
 			'email'              => $user->user_email,
 			'name'               => $full_name,


### PR DESCRIPTION
Fix to save the Alias instead of the name if the user doesn't have a name in WordPress.